### PR TITLE
Make the db folder configurable

### DIFF
--- a/atomic-config.php
+++ b/atomic-config.php
@@ -8,6 +8,7 @@ function getConfig() {
   $config['preCssDir'] = 'scss'; //Scss preprocessor directory name. E.G sass, less
   $config['preCssExt'] = 'scss'; //prerocessed file ext. E.G. scss, sass, less
   $config['compExt'] = 'php'; //markup file ext. E.G. html, twig, etc...
+  $config['dbPath'] = 'atomic-core/db'; //path of the db folder
 
   return $config;
 }

--- a/atomic-config.php
+++ b/atomic-config.php
@@ -8,7 +8,7 @@ function getConfig() {
   $config['preCssDir'] = 'scss'; //Scss preprocessor directory name. E.G sass, less
   $config['preCssExt'] = 'scss'; //prerocessed file ext. E.G. scss, sass, less
   $config['compExt'] = 'php'; //markup file ext. E.G. html, twig, etc...
-  $config['dbPath'] = 'atomic-core/db'; //path of the db folder
+  $config['dbPath'] = 'db'; //path of the db folder (relative to atomic-core)
 
   return $config;
 }

--- a/atomic-core/index.php
+++ b/atomic-core/index.php
@@ -1,8 +1,17 @@
 <?php include("head.php"); ?>
 <?php
 require "fllat.php";
-$compdb = new Fllat("compdb");
-$catdb = new Fllat("catdb");
+require "../atomic-config.php";
+
+
+$config = getConfig();
+$dbPath = $config['dbPath'];
+if(!$dbPath){
+  $dbPath = "db";
+}
+
+$compdb = new Fllat("compdb",$dbPath);
+$catdb = new Fllat("catdb",$dbPath);
 
 
 $comp_data = $compdb->select(array());
@@ -229,8 +238,3 @@ $cat_data = $catdb->select(array());
         display:inline-block;
     }
 </style>
-
-
-
-
-


### PR DESCRIPTION
This change aims to allow users to define the location of the `db` folder. By doing do users can move it outside of `atomic-core` to make updating atomic-docs core files easier in the long run.