### PR TITLE
Disabled worker-html.js from ace editor onload

### DIFF
--- a/atomic-core/footer.php
+++ b/atomic-core/footer.php
@@ -48,6 +48,7 @@ foreach ($compSelect as $component) {
     <script>
         var editormarkup_<?php echo $i; ?> = ace.edit("editor-markup-<?php echo $component['component'] ?>");
         var code = editormarkup_<?php echo $i; ?>.getValue();
+        editormarkup_<?php echo $i; ?>.getSession().setUseWorker(false);
         editormarkup_<?php echo $i; ?>.getSession().on('change', function () {
             $("input[name=new-markup-val-<?php echo $component['component'] ?>]").val(editormarkup_<?php echo $i; ?>.getSession().getValue());
         });
@@ -61,12 +62,13 @@ foreach ($compSelect as $component) {
         });
         editormarkup_<?php echo $i; ?>.setHighlightActiveLine(false);
         editormarkup_<?php echo $i; ?>.setShowPrintMargin(false);
-        
+
 
     </script>
     <script>
         var editorstyles_<?php echo $i; ?> = ace.edit("editor-styles-<?php echo $component['component'] ?>");
         var code = editorstyles_<?php echo $i; ?>.getValue();
+        editorstyles_<?php echo $i; ?>.getSession().setUseWorker(false);
         editorstyles_<?php echo $i; ?>.getSession().on('change', function () {
             $("input[name=new-styles-val-<?php echo $component['component'] ?>]").val(editorstyles_<?php echo $i; ?>.getSession().getValue());
         });


### PR DESCRIPTION
This fixes the issue of the ace editor from loading in worker-html.js for each editor on the page, I have tested it on my side and things seem to be working BUT if someone else could test it just to be sure.  