### PR TITLE
Easy start with docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+   php:
+     image: "php:7.0-apache"
+     ports:
+      - "8002:80"
+     volumes:
+      - .:/var/www/html


### PR DESCRIPTION
Let people who don't know much about local server infrastructure get started fast and easy with the php-apache docker image.
Download and install docker runtime from www.docker.com.

In terminal:
$ cd /local/your/project
$ docker-compose up -d

-> Surf to localhost:8002