### PR TITLE
Fixes github stars overlapping menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -54,7 +54,6 @@ layout: default
             text-align: right;
             padding: 10px;
             position: fixed;
-            width: 100%;
             z-index: 1000;   
         }
     </style>


### PR DESCRIPTION
This actually changes the position of the github stars widget, but it was overlapping the Demo | Github | Documentation menu 💅