### PR TITLE
add space after ## to fix markdown syntax issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,41 +8,41 @@ Documentation can be found at <a href="http://atomicdocs.io/">AtomicDocs.io</a>.
 
 <img src="atomic-core/img/demo1.gif" alt="atomic docs gif" />
 
-##Set up
+## Set up
 
 1. Download Atomic Docs and add to your local PHP environment.
 2. Configure your preprocessor to output `scss/main.scss` to `css/main.css`.
 3. Go to `http://localhost/atomic-docs/atomic-core/index.php` and get started.
 
-##Document
+## Document
 Have full documentation to hand off to other teams, internal or external.
 
 <img src="atomic-core/img/document.png" />
 
-##Edit in the Browser
+## Edit in the Browser
 Edit your components directly in the browser using the Ace.js editor.
 
 <img src="atomic-core/img/editor-gif.gif" />
 
 
-##Organize
+## Organize
 Organize all your components under categories that you name. "Base", "Modules", "Atoms" etc...
 
 <img src="atomic-core/img/organize.png"/>
 
-##Manage
+## Manage
 Manage all your components. Move, rename and delete with a clean GUI interface.
 
 <img src="atomic-core/img/manage.gif" />
 
-##Save time
+## Save time
 Does all the "wiring" of your SCSS partials. Never write `@import "partial-name";` again.
 
 <img width="500" src="atomic-core/img/helpful.png"/>
 
 Documentation can be found at <a href="http://atomicdocs.io/">AtomicDocs.io</a>.
 
-##Join the conversation!
+## Join the conversation!
 We'd love to hear your thoughts and suggestions. Join us on <a href="https://nick578.typeform.com/to/NwX0ox">Slack</a>.
 
 


### PR DESCRIPTION
Duplicate of https://github.com/nickberens360/atomic-docs/pull/59/files, so I am closing this.

## Purpose
It would seem that the readme has improper markdown header syntax, which results in no visual separation between sections.

## Description of changes
This PR adds spaces after the `##` for each header (h2) line.

### PS
Thanks, for the great work here in this repo